### PR TITLE
feat: 注文履歴の個数カラム対応およびメールアドレス設定の移行

### DIFF
--- a/src/utils/configService.js
+++ b/src/utils/configService.js
@@ -67,6 +67,7 @@ function _loadAndBuildFullConfig() {
     const botToken = sheet.getRange(SLACK_BOT_TOKEN_CELL).getValue();
     const channelId = sheet.getRange(SLACK_CHANNEL_ID_CELL).getValue();
     const orderAppUrl = sheet.getRange(ORDER_APP_URL_CELL).getValue();
+    const bentoMailAddress = sheet.getRange(C_MAIL_ADRESS_CELL).getValue();
 
     // 必須項目のチェック
     if (!geminiPrompt || !gmailQuery || !botToken || !channelId) {
@@ -80,6 +81,7 @@ function _loadAndBuildFullConfig() {
       modelName: modelName,
       gmailQuery: gmailQuery,
       orderAppUrl: orderAppUrl,
+      bentoMailAddress: bentoMailAddress,
       slack: {
         botToken: botToken,
         channelId: channelId

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -78,8 +78,7 @@ const PROPERTY_KEYS = {
   FOLDER_ID_MENU: 'FOLDER_ID_MENU',
   FOLDER_ID_ORDER_CARD: 'FOLDER_ID_ORDER_CARD',
   SPREADSHEET_ID: 'SPREADSHEET_ID',
-  GEMINI_API_KEY: 'GEMINI_API_KEY',
-  BENTO_MAIL_ADDRESS: 'BENTO_MAIL_ADDRESS'
+  GEMINI_API_KEY: 'GEMINI_API_KEY'
 };
 
 // ========================================
@@ -150,7 +149,8 @@ const ORDER_HISTORY_COLUMNS = {
   ORDER_PERSON_NAME: 2,  // C列 - 注文者名
   ORDER_DATE: 3,         // D列 - 対象日付
   STORE_NAME: 4,         // E列 - 店名
-  ORDER_SIZE: 6          // G列 - サイズ
+  ORDER_SIZE: 6,         // G列 - サイズ
+  ORDER_COUNT: 7         // H列 - 個数
 };
 
 const MENU_COLUMNS = {
@@ -164,7 +164,8 @@ const SNAPSHOT_COLUMNS = {
   ORDER_DATE: 1,    // B列 - 日付 (YYYY/MM/DD)
   ORDER_NAME: 2,    // C列 - 注文者
   ORDER_SIZE: 3,    // D列 - サイズ
-  SAVED_AT: 4       // E列 - 保存日時
+  ORDER_COUNT: 4,   // E列 - 個数
+  SAVED_AT: 5       // F列 - 保存日時
 };
 
 // ========================================

--- a/src/utils/dataFetcher.js
+++ b/src/utils/dataFetcher.js
@@ -44,11 +44,16 @@ function getLunchOrdersForNextWeek(nextWeekdays) {
           if (orderDateStr === targetDateStr) {
             const name = row[ORDER_HISTORY_COLUMNS.ORDER_PERSON_NAME];
             const size = row[ORDER_HISTORY_COLUMNS.ORDER_SIZE];
+            // 個数を取得（数値に変換、空や不正な値の場合は1をデフォルトにする）
+            const countValue = row[ORDER_HISTORY_COLUMNS.ORDER_COUNT];
+            const count = (countValue && !isNaN(countValue)) ? Number(countValue) : 1;
+            
             if (name && size) { // 注文者名とサイズが空でないことを確認
               orders.push({
                 date: orderDateStr,
                 name: name,
-                size: size
+                size: size,
+                count: count
               });
             }
           }

--- a/src/utils/messageFormatter.js
+++ b/src/utils/messageFormatter.js
@@ -29,7 +29,8 @@ function formatOrderChangesForSlack(changes, weekType, detectedAt) {
     message += '【追加】\n';
     changes.added.forEach(change => {
       const formattedDate = formatJapaneseDateWithDay(change.date);
-      message += `- ${formattedDate} ${change.name} ${change.size}\n`;
+      const countLabel = change.count > 1 ? ` (${change.count}個)` : '';
+      message += `- ${formattedDate} ${change.name} ${change.size}${countLabel}\n`;
     });
     message += '\n';
   }
@@ -39,7 +40,8 @@ function formatOrderChangesForSlack(changes, weekType, detectedAt) {
     message += '【キャンセル】\n';
     changes.cancelled.forEach(change => {
       const formattedDate = formatJapaneseDateWithDay(change.date);
-      message += `- ${formattedDate} ${change.name} ${change.size}\n`;
+      const countLabel = change.count > 1 ? ` (${change.count}個)` : '';
+      message += `- ${formattedDate} ${change.name} ${change.size}${countLabel}\n`;
     });
     message += '\n';
   }
@@ -52,7 +54,7 @@ function formatOrderChangesForSlack(changes, weekType, detectedAt) {
 /**
  * 取得したランチ注文データをSlackメッセージ用に整形します。
  *
- * @param {Array<Object>} orders 取得した注文データの配列。各オブジェクトは { date: string, name: string, size: string } の形式。
+ * @param {Array<Object>} orders 取得した注文データの配列。各オブジェクトは { date: string, name: string, size: string, count: number } の形式。
  * @returns {string} 整形されたSlackメッセージ文字列。
  */
 function formatLunchOrdersForSlack(orders) {
@@ -66,7 +68,7 @@ function formatLunchOrdersForSlack(orders) {
     if (!acc[date]) {
       acc[date] = [];
     }
-    acc[date].push({ name: order.name, size: order.size });
+    acc[date].push({ name: order.name, size: order.size, count: order.count });
     return acc;
   }, {});
 
@@ -77,7 +79,10 @@ function formatLunchOrdersForSlack(orders) {
     const formattedDate = formatJapaneseDateWithDay(dateStr); // MM/DD (曜日) 形式に変換
     const dailyOrders = groupedOrders[dateStr];
 
-    const orderDetails = dailyOrders.map(order => `${order.name} ${order.size}`).join(', ');
+    const orderDetails = dailyOrders.map(order => {
+      const countLabel = order.count > 1 ? ` (${order.count}個)` : '';
+      return `${order.name} ${order.size}${countLabel}`;
+    }).join(', ');
     message += `- ${formattedDate}: ${orderDetails}\n`;
   });
 

--- a/src/utils/propertyManager.js
+++ b/src/utils/propertyManager.js
@@ -47,15 +47,6 @@ class PropertyManager {
   }
 
   /**
-   * 弁当屋さんのメールアドレスを取得
-   * @returns {string} 弁当屋さんのメールアドレス
-   * @throws {AppError} プロパティが未設定の場合
-   */
-  getBentoMailAddress() {
-    return this._getRequired('BENTO_MAIL_ADDRESS');
-  }
-
-  /**
    * 必須プロパティを取得（未設定の場合はエラー）
    * @private
    * @param {string} key プロパティのキー


### PR DESCRIPTION
## 概要
AppSheetの注文フォームに「個数」項目が追加されたことに伴い、GAS側の集計・通
知・変更検知ロジックを改修し、複数個の注文に対応しました。
あわせて、弁当屋さんのメールアドレス設定をスクリプトプロパティからスプレッド
シート（情報シート）管理へ移行しました。

## 変更内容

1. 注文数の集計ロジック改修
 - データ取得:
   注文履歴シートのH列（インデックス7）から個数を取得するように変更。未入力
   や不正値の場合はデフォルトで「1」として扱います。
 - 集計処理:
   オーダーカード作成時、従来の「行数カウント」から「個数の合算」へ変更しま
   した。

2. 変更検知（スナップショット）の改修
 - スナップショット保存:
   注文スナップショットシートに「個数」列を追加し、時点ごとの個数を保存する
   ようにしました。
 - 差分検知:
   個数の変更も検知対象とし、数量の増減が正しく判定されるようにロジックを修
   正しました。

3. 通知フォーマットの変更
 - Slack通知: 注文一覧や変更通知において、個数が2個以上の場合に (2個)
   と明記するように変更しました。

4. 設定管理の変更
 - メールアドレス:
   弁当屋さんのメールアドレス（BENTO_MAIL_ADDRESS）の取得元を、スクリプトプ
   ロパティからスプレッドシートの「情報」シートB2セル（旧
   C_MAIL_ADRESS）に変更しました。
 - これに伴い、PropertyManager から該当メソッドを削除し、ConfigService
   経由で取得するように統一しました。

## 目的
 - ユーザーによる複数個注文（大盛1つ＋普通1つなど）や、同一商品の複数注文に
   対応し、発注漏れを防ぐため。
 - 設定値をスプレッドシートに集約することで、管理者が画面上から容易に宛先を
   変更できるようにするため。

## 動作確認
 - [x] 注文履歴に個数を入力し、オーダーカードに合算値が反映されることを確認
 - [x]
   スナップショットに個数が保存され、変更検知（追加・キャンセル・数量変更）
   が正しく動作することを確認
 - [x] Slack通知に個数が表示されることを確認
 - [x]
   メールアドレスがスプレッドシートから読み込まれ、下書き作成が成功すること
   を確認

## 関連イシュー
#14 