### PR TITLE
長期休暇対応のためメール検索期間を30日に延長

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -211,7 +211,7 @@ const SIZE_KEYWORDS = {
 // ========================================
 const GMAIL_SEARCH = {
   SUBJECT_KEYWORDS: ['弁当', 'お弁当'],
-  SEARCH_DAYS_BACK: 14, // 過去14日分を検索
+  SEARCH_DAYS_BACK: 30, // 過去30日分を検索
   INVOICE_SEARCH_DAYS: 1, // 請求書検索の対象日数
 };
 


### PR DESCRIPTION
長期休暇（連休）前に送信されたオーダーメールが14日以上前になる場合があるため、メールの検索期間を従来の14日から30日に延長しました。これにより、連休明けの注文変更検知が正常に動作するようになります。